### PR TITLE
FIX: Fixes dot() returning NaN.

### DIFF
--- a/arithmetic.go
+++ b/arithmetic.go
@@ -227,11 +227,23 @@ func dot(a, b []float64) float64 {
 	result, dimA, dimB := 0., len(a), len(b)
 
 	if dimA == 2 && dimB == 2 {
-		return a[x]*b[x] + a[y]*b[y]
+		result = a[x]*b[x] + a[y]*b[y]
+		if result > 1 {
+			result = 1
+		} else if result < -1 {
+			result = -1
+		}
+		return result
 	}
 
 	if dimA == 3 && dimB == 3 {
-		return a[x]*b[x] + a[y]*b[y] + a[z]*b[z]
+		result = a[x]*b[x] + a[y]*b[y] + a[z]*b[z]
+		if result > 1 {
+			result = 1
+		} else if result < -1 {
+			result = -1
+		}
+		return result
 	}
 
 	if dimA > dimB {
@@ -244,6 +256,12 @@ func dot(a, b []float64) float64 {
 
 	for i := range a {
 		result += a[i] * b[i]
+	}
+
+	if result > 1 {
+		result = 1
+	} else if result < -1 {
+		result = -1
 	}
 
 	return result

--- a/vector_test.go
+++ b/vector_test.go
@@ -100,3 +100,20 @@ func TestSwizzling(t *testing.T) {
 	}
 
 }
+
+func TestDotNaN(t *testing.T) {
+	v1 := vec{1, 0, 0}
+	v2 := vec{0, 1, 0}
+
+	if v1.Dot(v2) != 0 {
+		t.Error("dot function did not return values expected")
+	}
+
+	v1 = vector.Vector{-0.9040721420170615, 0, 0.4273798802338293}
+	v2 = v1.Invert()
+
+	if math.IsNaN(v1.Dot(v2)) {
+		t.Error("dot function returned NaN")
+	}
+
+}


### PR DESCRIPTION
Here's a PR to fix angle() sometimes returning NaN with specific long-running vectors; this is probably due to floating-point inaccuracies.

As an example, without this PR, this:
```go
v := vector.Vector{-0.9040721420170615, 0, 0.4273798802338293}
fmt.Println(v.Angle(v))
```
returns NaN instead of 0 (and similarly NaN instead of `pi` if the vector were to be tested against its opposite).